### PR TITLE
Update to Minecraft: Java Edition 26.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@4075bfc1b51bf22876335ae1cd589602d60d8758
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
       - name: Publish to Modrinth (Fabric)
         if: ${{ success() && github.repository == 'onebeastchris/Hurricane-Modded' && github.ref_name == '1.21' }}
         env:

--- a/buildSrc/src/main/kotlin/hurricane.base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/hurricane.base-conventions.gradle.kts
@@ -12,7 +12,7 @@ tasks {
                 "description" to "Hacky fixes to make Bedrock players that join via Geyser happy. Fabric port of Hurricane by GeyserMC.",
                 "url" to "https://geysermc.org",
                 "author" to "onebeastchris",
-                "minecraft_version" to "1.21.3"
+                "minecraft_version" to "26.1"
             )
         }
     }

--- a/buildSrc/src/main/kotlin/hurricane.platform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/hurricane.platform-conventions.gradle.kts
@@ -1,10 +1,7 @@
-import gradle.kotlin.dsl.accessors._e054d9723d982fdb55b1e388b8ab0cbf.build
-import net.fabricmc.loom.task.RemapJarTask
-
 plugins {
     id("hurricane.shadow-conventions")
     id("architectury-plugin")
-    id("dev.architectury.loom")
+    id("dev.architectury.loom-no-remap")
     id("com.modrinth.minotaur")
 }
 
@@ -22,34 +19,39 @@ loom {
 
 dependencies {
     minecraft(libs.minecraft)
-    mappings(loom.officialMojangMappings())
 }
 
 tasks {
     shadowJar {
         // Mirrors the example fabric project, otherwise tons of dependencies are shaded that shouldn't be
-        configurations = listOf(project.configurations.shadow.get())
+        configurations = listOf(project.configurations.getByName("shadow"))
+        archiveBaseName.set("${project.name}-shaded")
+        mergeServiceFiles()
+    }
 
-        // The remapped shadowJar is the final desired mod jar
+    // This task combines the output of the "jar" task, which includes JiJ dependencies,
+    // and the shadowJar for the final jar.
+    // thanks bluemap
+    // https://github.com/BlueMap-Minecraft/BlueMap/blob/cfe73115dc4d1bdd97bc659f41364da65a6a2179/implementations/fabric/build.gradle.kts#L93-L107
+    register<Jar>("mergeShadowAndJarJar") {
+        dependsOn( tasks.shadowJar, tasks.jar )
+        // from sources / final name are configured in the respective projects
         archiveVersion.set("")
+        archiveClassifier.set("")
     }
 
-    remapJar {
-        dependsOn(shadowJar)
-        inputFile.set(shadowJar.get().archiveFile)
-        archiveClassifier.set("")
-        archiveVersion.set(project.version.toString())
-    }
+    tasks.register<Copy>("renameModrinthJar") {
+        val sourceJar = tasks.named<Jar>("mergeShadowAndJarJar")
+        dependsOn(sourceJar)
 
-    register("remapModrinthJar", RemapJarTask::class) {
-        dependsOn(shadowJar)
-        inputFile.set(shadowJar.get().archiveFile)
-        archiveVersion.set(project.version.toString() + "+build."  + System.getenv("GITHUB_RUN_NUMBER"))
-        archiveClassifier.set("")
+        from(sourceJar.flatMap { it.archiveFile })
+        into(layout.buildDirectory.dir("libs"))
+
+        rename { "${(project)}.jar" }
     }
 
     build {
-        dependsOn(remapJar)
+        dependsOn(tasks.getByName("mergeShadowAndJarJar"))
     }
 }
 
@@ -62,7 +64,7 @@ modrinth {
     syncBodyFrom.set(rootProject.file("README.md").readText())
     changelog.set(rootProject.file("CHANGELOG.md").readText())
 
-    uploadFile.set(tasks.getByPath("remapModrinthJar"))
-    gameVersions.addAll("1.21.3")
+    uploadFile.set(tasks.getByPath("renameModrinthJar"))
+    gameVersions.addAll("26.1")
     failSilently.set(false)
 }

--- a/buildSrc/src/main/kotlin/hurricane.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/hurricane.shadow-conventions.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     id("hurricane.base-conventions")
-    id("com.github.johnrengelman.shadow")
+    id("com.gradleup.shadow")
 }
 
 tasks {

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -23,7 +23,7 @@ tasks {
                 include("fabric.mod.json")
             }
         )
-        archiveBaseName.set("Geyser-Fabric")
+        archiveBaseName.set("hurricane-fabric")
     }
 }
 

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -13,18 +13,24 @@ configurations {
 }
 
 tasks {
-    remapJar {
-        archiveBaseName.set("hurricane-fabric")
-    }
-    remapModrinthJar {
-        archiveBaseName.set("hurricane-fabric")
+    named<Jar>("mergeShadowAndJarJar") {
+        from (
+            zipTree( shadowJar.map { it.outputs.files.singleFile } ).matching {
+                exclude("fabric.mod.json")
+            },
+            zipTree( jar.map { it.outputs.files.singleFile } ).matching {
+                include("META-INF/jars/**")
+                include("fabric.mod.json")
+            }
+        )
+        archiveBaseName.set("Geyser-Fabric")
     }
 }
 
 dependencies {
-    modImplementation(libs.fabric.loader)
-    modApi(libs.fabric.api)
-    common(project(":shared", configuration = "namedElements")) { isTransitive = false }
+    implementation(libs.fabric.loader)
+    api(libs.fabric.api)
+    common(project(":shared")) { isTransitive = false }
     shadow(project(path = ":shared", configuration = "transformProductionFabric")) {
         isTransitive = false
     }
@@ -34,10 +40,10 @@ dependencies {
     include(libs.geantyref)
     include(libs.typesafe)
 
-    modLocalRuntime(libs.configurate.hocon)
-    modLocalRuntime(libs.configurate.core)
-    modLocalRuntime(libs.geantyref)
-    modLocalRuntime(libs.typesafe)
+    localRuntime(libs.configurate.hocon)
+    localRuntime(libs.configurate.core)
+    localRuntime(libs.geantyref)
+    localRuntime(libs.typesafe)
 }
 
 modrinth {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,31 +1,31 @@
 [versions]
-geyser = "2.2.3-SNAPSHOT"
-shadow = "8.1.1"
-architectury-plugin = "3.4-SNAPSHOT"
-architectury-loom = "1.7-SNAPSHOT"
-minecraft-version = "1.21.3"
+geyser = "2.9.5-SNAPSHOT"
+shadow = "9.4.1"
+architectury-plugin = "3.5-SNAPSHOT"
+architectury-loom = "1.14-SNAPSHOT"
+minecraft-version = "26.1.2"
 minotaur = "2.+"
-lombok = "8.6"
+lombok = "9.5.0"
 mixin = "0.8.5"
 configurate = "4.1.2"
 typesafe = "1.4.2"
 geantyref = "1.3.14"
 asm = "5.2"
-floodgate = "2.2.3-SNAPSHOT"
+floodgate = "2.2.5-SNAPSHOT"
 
 # fabric
-fabric-loader = "0.16.8"
-fabric-api = "0.107.3+1.21.3"
+fabric-loader = "0.19.2"
+fabric-api = "0.147.0+26.1.2"
 
 # neoforge
-neoforge-version = "21.3.0-beta"
+neoforge-version = "26.1.2.31-beta"
 
 [libraries]
 geyser-api = { group = "org.geysermc.geyser", name = "api", version.ref = "geyser" }
 floodgate-api = { group = "org.geysermc.floodgate", name = "api", version.ref = "floodgate" }
-shadow = { group = "com.github.johnrengelman", name = "shadow", version.ref = "shadow" }
+shadow = { group = "com.gradleup.shadow", name = "com.gradleup.shadow.gradle.plugin", version.ref = "shadow" }
 architectury-plugin = { group = "architectury-plugin", name = "architectury-plugin.gradle.plugin", version.ref = "architectury-plugin" }
-architectury-loom = { group = "dev.architectury.loom", name = "dev.architectury.loom.gradle.plugin", version.ref = "architectury-loom" }
+architectury-loom = { group = "dev.architectury.loom-no-remap", name = "dev.architectury.loom-no-remap.gradle.plugin", version.ref = "architectury-loom" }
 minotaur = { group = "com.modrinth.minotaur", name = "Minotaur", version.ref = "minotaur" }
 mixin = { group = "org.spongepowered", name = "mixin", version.ref = "mixin" }
 asm = { group = "org.ow2.asm", name = "asm-debug-all", version.ref = "asm" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -33,7 +33,7 @@ tasks {
                 include("META-INF/jarjar/**")
             }
         )
-        archiveBaseName.set("Geyser-NeoForge")
+        archiveBaseName.set("hurricane-neoforge")
     }
 }
 

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -15,7 +15,7 @@ configurations {
 
 dependencies {
     neoForge(libs.neoforge)
-    common(project(":shared", configuration = "namedElements")) { isTransitive = false }
+    common(project(":shared")) { isTransitive = false }
     shadow(project(path = ":shared", configuration = "transformProductionNeoForge")) { isTransitive = false }
 
     include(libs.configurate.hocon)
@@ -25,11 +25,15 @@ dependencies {
 }
 
 tasks {
-    remapJar {
-        archiveBaseName.set("hurricane-neoforge")
-    }
-    remapModrinthJar {
-        archiveBaseName.set("hurricane-neoforge")
+    named<Jar>("mergeShadowAndJarJar") {
+        from(
+            zipTree(shadowJar.map { it.outputs.files.singleFile }),
+            zipTree(jar.map { it.outputs.files.singleFile }).matching {
+                include("META-INF/jars/**")
+                include("META-INF/jarjar/**")
+            }
+        )
+        archiveBaseName.set("Geyser-NeoForge")
     }
 }
 

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -15,7 +15,7 @@ config = "hurricane.mixins.json"
 [[dependencies.hurricane]]
 modId="neoforge"
 type="required"
-versionRange="[21.3.0-beta,)"
+versionRange="[26.1.0.1-beta,)"
 ordering="NONE"
 side="BOTH"
 [[dependencies.hurricane]]

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -2,10 +2,6 @@ architectury {
     common("neoforge", "fabric")
 }
 
-loom {
-    mixin.defaultRefmapName.set("hurricane-refmap.json")
-}
-
 dependencies {
     compileOnly(libs.floodgate.api)
     compileOnly(libs.geyser.api)


### PR DESCRIPTION
This PR updates Hurricane-Modded to support Minecraft: Java Edition 26.1. 

The buildscript needs some work. I'm not an expert at it.

Note: This version of the mod is not backwards compatible.